### PR TITLE
Use gleam_yielder instead of the deprecated gleam/iterator

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ and its documentation can be found at <https://hexdocs.pm/ranger>.
 
 ```gleam
 import gleam/float
+import gleam/yielder
 import ranger
 
 pub fn main() {
@@ -41,6 +42,6 @@ pub fn main() {
 
   let assert Ok(z_to_p) = range("z", "p", 1)
   z_to_p
-  |> iterator.to_list
+  |> yielder.to_list
 }
 ```

--- a/gleam.toml
+++ b/gleam.toml
@@ -8,7 +8,8 @@ links = [{ title = "Gleam", href = "https://gleam.run" }]
 repository = { type = "github", user = "massivefermion", repo = "ranger" }
 
 [dependencies]
-gleam_stdlib = ">= 0.43.0 and < 2.0.0"
+gleam_stdlib = ">= 0.44.0 and < 2.0.0"
+gleam_yielder = ">= 1.0.0 and < 2.0.0"
 
 [dev-dependencies]
 gleeunit = ">= 1.2.0 and < 2.0.0"

--- a/manifest.toml
+++ b/manifest.toml
@@ -2,10 +2,12 @@
 # You typically do not need to edit this file
 
 packages = [
-  { name = "gleam_stdlib", version = "0.43.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "69EF22E78FDCA9097CBE7DF91C05B2A8B5436826D9F66680D879182C0860A747" },
+  { name = "gleam_stdlib", version = "0.44.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "A6E55E309A6778206AAD4038D9C49E15DF71027A1DB13C6ADA06BFDB6CF1260E" },
+  { name = "gleam_yielder", version = "1.0.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_yielder", source = "hex", outer_checksum = "44C8DE196A10634667F5F7B93128A997B35DFD37E26F775D749BC6A239B499A8" },
   { name = "gleeunit", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "F7A7228925D3EE7D0813C922E062BFD6D7E9310F0BEE585D3A42F3307E3CFD13" },
 ]
 
 [requirements]
-gleam_stdlib = { version = ">= 0.43.0 and < 2.0.0" }
+gleam_stdlib = { version = ">= 0.44.0 and < 2.0.0" }
+gleam_yielder = { version = ">= 1.0.0 and < 2.0.0" }
 gleeunit = { version = ">= 1.2.0 and < 2.0.0" }

--- a/test/ranger_test.gleam
+++ b/test/ranger_test.gleam
@@ -1,5 +1,5 @@
-import gleam/iterator
 import gleam/string
+import gleam/yielder
 
 import gleeunit
 import gleeunit/should
@@ -40,7 +40,7 @@ pub fn a_to_e_test() {
     compare: string.compare,
   )("a", "e", -1)
   |> should.be_ok
-  |> iterator.to_list
+  |> yielder.to_list
   |> should.equal(["a", "b", "c", "d", "e"])
 }
 
@@ -58,7 +58,7 @@ pub fn z_to_p_double_step_test() {
     compare: string.compare,
   )("z", "p", -2)
   |> should.be_ok
-  |> iterator.to_list
+  |> yielder.to_list
   |> should.equal(["z", "x", "v", "t", "r", "p"])
 }
 
@@ -76,6 +76,6 @@ pub fn z_to_p_triple_step_test() {
     compare: string.compare,
   )("z", "p", 3)
   |> should.be_ok
-  |> iterator.to_list
+  |> yielder.to_list
   |> should.equal(["z", "w", "t", "q"])
 }


### PR DESCRIPTION
`gleam/iterator` has been deprecated in stdlib 0.44 in favour of the `gleam_yielder` package.